### PR TITLE
(Upgrade to buffalo 0.11.x) Use the right uuid package

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
 	"golang.org/x/crypto/bcrypt"
 )
 


### PR DESCRIPTION
I'm using these recipes to learn buffalo (great resource!), and therefore finding all these post 0.11 quirks :)

Hopefully my contributions will become more meaningful over time.

Without this fix, the following error is thrown when trying to register a new user in the app

```
interface conversion: interface {} is uuid.UUID, not uuid.UUID
```
